### PR TITLE
chore: drop python 3.9

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     rev: v3.20.0
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py310-plus]
 
   - repo: https://github.com/DanielNoord/pydocstringformatter
     rev: v0.7.5

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Official wrapper for the [Cookie](https://cookieapp.me) API.
 
 ## ⚙️ Installation
-Python 3.9 or higher is required
+Python 3.10 or higher is required
 ```
 pip install cookie-api
 ```

--- a/cookie/_internal/model_generator.py
+++ b/cookie/_internal/model_generator.py
@@ -16,7 +16,7 @@ generate(
     use_union_operator=True,
     use_double_quotes=True,
     use_standard_collections=True,
-    target_python_version=PythonVersion.PY_39,
+    target_python_version=PythonVersion.PY_310,
     custom_formatters=["formatter"],
     output=Path("cookie/models.py"),
     output_model_type=DataModelType.PydanticV2BaseModel,

--- a/cookie/models.py
+++ b/cookie/models.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from datetime import date, datetime
+from datetime import date
 
-from pydantic import BaseModel, Field
+from pydantic import AwareDatetime, BaseModel, Field
 
 from ._internal import BaseChart
 
@@ -17,7 +17,7 @@ class Chart(BaseChart):
 
 class Daily(BaseModel):
     ready: bool = Field(..., title="Ready")
-    next: datetime = Field(..., title="Next")
+    next: AwareDatetime = Field(..., title="Next")
     streak: int = Field(..., title="Streak")
     max_streak: int = Field(..., title="Max Streak")
 
@@ -50,7 +50,7 @@ class MemberActivity(BaseModel):
 
 class Oven(BaseModel):
     ready: bool = Field(..., title="Ready")
-    next: datetime = Field(..., title="Next")
+    next: AwareDatetime = Field(..., title="Next")
 
 
 class Steals(BaseModel):
@@ -89,13 +89,13 @@ class VoiceLevel(BaseModel):
 
 
 class Work(BaseModel):
-    career: str = Field(..., title="Career")
+    career: str | None = Field(..., title="Career")
     total_shifts: int = Field(..., title="Total Shifts")
     current_shifts: int = Field(..., title="Current Shifts")
-    job: str = Field(..., title="Job")
+    job: str | None = Field(..., title="Job")
     job_level: int = Field(..., title="Job Level")
     job_ready: bool = Field(..., title="Job Ready")
-    next_shift: datetime = Field(..., title="Next Shift")
+    next_shift: AwareDatetime = Field(..., title="Next Shift")
 
 
 class HTTPValidationError(BaseModel):

--- a/cookie/models.py
+++ b/cookie/models.py
@@ -3,9 +3,9 @@
 
 from __future__ import annotations
 
-from datetime import date
+from datetime import date, datetime
 
-from pydantic import AwareDatetime, BaseModel, Field
+from pydantic import BaseModel, Field
 
 from ._internal import BaseChart
 
@@ -17,7 +17,7 @@ class Chart(BaseChart):
 
 class Daily(BaseModel):
     ready: bool = Field(..., title="Ready")
-    next: AwareDatetime = Field(..., title="Next")
+    next: datetime = Field(..., title="Next")
     streak: int = Field(..., title="Streak")
     max_streak: int = Field(..., title="Max Streak")
 
@@ -50,7 +50,7 @@ class MemberActivity(BaseModel):
 
 class Oven(BaseModel):
     ready: bool = Field(..., title="Ready")
-    next: AwareDatetime = Field(..., title="Next")
+    next: datetime = Field(..., title="Next")
 
 
 class Steals(BaseModel):
@@ -95,7 +95,7 @@ class Work(BaseModel):
     job: str | None = Field(..., title="Job")
     job_level: int = Field(..., title="Job Level")
     job_ready: bool = Field(..., title="Job Ready")
-    next_shift: AwareDatetime = Field(..., title="Next Shift")
+    next_shift: datetime = Field(..., title="Next Shift")
 
 
 class HTTPValidationError(BaseModel):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "cookie-api"
 description = "An API wrapper for the Cookie API"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = {text = "MIT"}
 readme = "README.md"
 keywords = ["discord", "bot", "cookie", "api"]
@@ -13,7 +13,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,3 @@
 httpx
 pydantic
 python-dotenv
-eval_type_backport; python_version<='3.9'


### PR DESCRIPTION
Python 3.9 has reached EOL: https://devguide.python.org/versions/